### PR TITLE
Add missing string validation for unlimitied character varying colums

### DIFF
--- a/lib/active_record_doctor/printers/io_printer.rb
+++ b/lib/active_record_doctor/printers/io_printer.rb
@@ -87,7 +87,8 @@ EOS
         return if missing_string_length_validators.empty?
 
         @io.puts('The following models and columns should have length validations:')
-        missing_string_length_validators.each do |model_name, array_of_columns|
+        missing_string_length_validators.keys.sort.each do |model_name|
+          array_of_columns = missing_string_length_validators[model_name].sort
           @io.puts("  #{model_name}: #{array_of_columns.join(', ')}")
         end
       end

--- a/lib/active_record_doctor/printers/io_printer.rb
+++ b/lib/active_record_doctor/printers/io_printer.rb
@@ -83,6 +83,15 @@ EOS
         end
       end
 
+      def missing_string_length_validation(missing_string_length_validators)
+        return if missing_string_length_validators.empty?
+
+        @io.puts('The following models and columns should have length validations:')
+        missing_string_length_validators.each do |model_name, array_of_columns|
+          @io.puts("  #{model_name}: #{array_of_columns.join(', ')}")
+        end
+      end
+
       def missing_non_null_constraint(missing_non_null_constraints)
         return if missing_non_null_constraints.empty?
 

--- a/lib/active_record_doctor/tasks/missing_string_length_validation.rb
+++ b/lib/active_record_doctor/tasks/missing_string_length_validation.rb
@@ -1,0 +1,66 @@
+require "active_record_doctor/tasks/base"
+
+module ActiveRecordDoctor
+  module Tasks
+    class MissingStringLengthValidation < Base
+      @description = 'Detect unlimited character varying columns without length/inclusion validators'
+
+      def run
+        eager_load!
+
+        success(hash_from_pairs(models.reject do |model|
+          model.table_name.nil? || model.table_name == 'schema_migrations' || !model.table_exists?
+        end.map do |model|
+          [
+            model.name,
+            connection.columns(model.table_name).select do |column|
+              validator_needed?(column) &&
+                !sti_type_column?(model, column) &&
+                !polymorphic_type_column?(model, column) &&
+                !validator_present?(model, column)
+            end.map(&:name)
+          ]
+        end.reject do |model_name, columns|
+          columns.empty?
+        end))
+      end
+
+      private
+
+      def validator_needed?(column)
+        column.type == :string && column.limit.nil?
+      end
+
+      def sti_type_column?(model, column)
+        column.name == model.inheritance_column
+      end
+
+      def polymorphic_type_column?(model, column)
+        model.reflect_on_all_associations(:belongs_to).any? do |reflection|
+          reflection.options.fetch(:polymorphic, false) && reflection.foreign_type == column.name
+        end
+      end
+
+      def validator_present?(model, column)
+        length_validator_present?(model, column) ||
+          inclusion_validator_present?(model, column)
+      end
+
+      def length_validator_present?(model, column)
+        model.validators.any? do |validator|
+          validator.is_a?(ActiveModel::Validations::LengthValidator) &&
+            validator.attributes.include?(column.name.to_sym) &&
+            (!validator.options.key?(:minimum) ||
+              validator.options.key?(:minimum) && validator.options.key?(:maximum))
+        end
+      end
+
+      def inclusion_validator_present?(model, column)
+        model.validators.any? do |validator|
+          validator.is_a?(ActiveModel::Validations::InclusionValidator) &&
+            validator.attributes.include?(column.name.to_sym)
+        end
+      end
+    end
+  end
+end

--- a/lib/active_record_doctor/tasks/missing_string_length_validation.rb
+++ b/lib/active_record_doctor/tasks/missing_string_length_validation.rb
@@ -9,7 +9,7 @@ module ActiveRecordDoctor
         eager_load!
 
         success(hash_from_pairs(models.reject do |model|
-          model.table_name.nil? || model.table_name == 'schema_migrations' || !model.table_exists?
+          model.table_name.nil? || model.table_name == 'schema_migrations' || model.table_name == 'ar_internal_metadata' || !model.table_exists?
         end.map do |model|
           [
             model.name,

--- a/lib/tasks/active_record_doctor.rake
+++ b/lib/tasks/active_record_doctor.rake
@@ -8,6 +8,7 @@ require "active_record_doctor/tasks/missing_unique_indexes"
 require "active_record_doctor/tasks/missing_presence_validation"
 require "active_record_doctor/tasks/missing_non_null_constraint"
 require "active_record_doctor/tasks/incorrect_boolean_presence_validation"
+require "active_record_doctor/tasks/missing_string_length_validation"
 
 namespace :active_record_doctor do
   def mount(task_class)

--- a/test/active_record_doctor/tasks/missing_string_length_validation_test.rb
+++ b/test/active_record_doctor/tasks/missing_string_length_validation_test.rb
@@ -1,0 +1,88 @@
+
+require 'test_helper'
+
+require 'active_record_doctor/tasks/missing_string_length_validation'
+
+class ActiveRecordDoctor::Tasks::MissingStringLengthValidationTest < ActiveSupport::TestCase
+  def test_missing_validation_is_reported_on_string_only
+    Temping.create(:users, temporary: false) do
+      with_columns do |t|
+        t.string :name
+        t.boolean :active
+      end
+    end
+
+    assert_equal({ 'User' => ['name'] }, run_task)
+  end
+
+  def test_missing_validation_is_not_reported_on_type_column
+    Temping.create(:users, temporary: false) do
+      with_columns do |t|
+        t.string :name
+        t.string :type
+      end
+    end
+
+    assert_equal({ 'User' => ['name'] }, run_task)
+  end
+
+  def test_missing_validation_is_not_reported_on_polymorphic_type_column
+    Temping.create(:users, temporary: false) do
+      with_columns do |t|
+        t.string :name
+        t.string :access_type
+        t.integer :access_id
+      end
+
+      belongs_to :access, polymorphic: true
+    end
+
+    assert_equal({ 'User' => ['name'] }, run_task)
+  end
+
+  def test_missing_validation_is_not_reported_if_limit_present
+    Temping.create(:users, temporary: false) do
+      with_columns do |t|
+        t.string :name, limit: 10
+      end
+    end
+
+    assert_equal({}, run_task)
+  end
+
+  def test_missing_validation_is_not_reported_if_validation_present
+    Temping.create(:users, temporary: false) do
+      with_columns do |t|
+        t.string :name
+      end
+
+      validates :name, length: { maximum: 10 }
+    end
+
+    assert_equal({}, run_task)
+  end
+
+  def test_missing_validation_is_not_reported_if_validation_present_as_range
+    Temping.create(:users, temporary: false) do
+      with_columns do |t|
+        t.string :name
+      end
+
+      validates :name, length: { in: 1..10 }
+    end
+
+    assert_equal({}, run_task)
+  end
+
+  def test_missing_validation_is_reported_if_validation_maximum_is_not_present
+    Temping.create(:users, temporary: false) do
+      with_columns do |t|
+        t.string :name
+      end
+
+      validates :name, length: { minimum: 10 }
+    end
+
+    assert_equal({ 'User' => ['name'] }, run_task)
+  end
+end


### PR DESCRIPTION
Adding new string columns via Rails migration results in a character varying column without length specifier when using PosgreSQL adapter - https://github.com/rails/rails/blob/fbe2433be6e052a1acac63c7faf287c52ed3c5ba/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb#L103. These fields should have length or inclusion validations, otherwise there is a risk exposing an ability to insert large values and cause server-side DoS. 

The job detects missing string length/inclusion validators and report.

The output looks like:

```
The following models and columns should have length validations:
  User: name
``` 

This means `User` should have length or inclusion validator on `name`.